### PR TITLE
Don't shell out to rg if not in a tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,7 @@ Next
 Changes that will be in the next release
 
 * Add column to hyperer-rg and hyperer-cargo
+* Default to hyperlinking in hyperer-rg if we're not in a tty e.g. a pipe
+* Refuse to run hyperer-rg if a formatting option is given that breaks its parsing
 * Only require Python 3.9, not 3.10
 * Remove hyperer-rg flags from kitty

--- a/hyperer/rg.py
+++ b/hyperer/rg.py
@@ -6,12 +6,15 @@ import subprocess
 import sys
 from . import make_hyperlink, consume_process, strip_ansi
 
+# TODO - parse --colors to see if something other than red is being used for matches. Or maybe switch to matching on bold if it's only used for matches?
 match_pat = re.compile(b'\x1b\\[31m(.+?)\x1b\\[0m')
+
 def link_matches(line, path, line_num, prefix_width):
     # If we're able to find individual matches via their being colored, link to the column of each match
     last_match_end = 0
     for match in match_pat.finditer(line):
         yield line[last_match_end:match.start()]
+        # TODO - this is a byte offset into the line. It should likely be a unicode-aware character offset
         col_num = b'%d' % (len(strip_ansi(line[:match.start()])) + 1 - prefix_width)
         yield make_hyperlink(path, match.group(0),
             frag=line_num + b':' + col_num,
@@ -24,11 +27,12 @@ def link_matches(line, path, line_num, prefix_width):
         yield make_hyperlink(path, line, frag=line_num, params={b'line': line_num})
 
 def main(argv=sys.argv, write=None):
-    # TODO - skip urls if --json is given
-    if not sys.stdout.isatty() and '--pretty' not in argv and '-p' not in argv:
-        os.execlp('rg', 'rg', *argv[1:])
+    output_altering_flags = set(['--column', '--json', '-I', '--no-filename', '--no-heading', 
+        '-N', '--no-line-number', '--vimgrep'])
+    for arg in argv:
+        if arg in output_altering_flags:
+            raise SystemExit(f"hyperer-rg relies on the output format of rg and can't be used with the '{arg}' flag. Call rg directly to use it.")
 
-    # TODO - parse --colors to see if something other than red is being used for matches
     in_result: bytes = [b'']
     num_pat = re.compile(br'^(\d+):')
     def line_handler(write, raw_line, clean_line):

--- a/test_blackbox.py
+++ b/test_blackbox.py
@@ -1,3 +1,5 @@
+import pytest
+
 def test_rg():
     from hyperer.rg import main
     output = []
@@ -9,6 +11,13 @@ def test_rg():
 
     assert b'INCIDENTAL' in output[1], "The match line contains the searched word INCIDENTAL"
     assert output[1].endswith(b'THE\n')
+
+def test_no_format_altering_flags_rg():
+    from hyperer.rg import main
+    output = []
+    # Search for the one copy of the word 'INCIDENTAL' in the license file
+    with pytest.raises(SystemExit):
+        main(['hyperer-rg', '--column', 'INCIDENTAL', 'LICENSE'], output.append)
 
 def test_rg_multimatch():
     from hyperer.rg import main


### PR DESCRIPTION
If hyperer-rg is being called, we likely want to link. If you don't want links, you can always call rg directly.

Do fail hyperer-rg if an output breaking flag is used.